### PR TITLE
Implement `HttpServer` using `mio` crate.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 // TODO: Support implementing routes for handling different types of requests.
-// TODO: Reuse connections / leave connections intact.
+// TODO: Implement multi-threading with mio.
 
 fn main() {
     twebd::run();

--- a/src/srv/conn.rs
+++ b/src/srv/conn.rs
@@ -5,18 +5,99 @@ use std::io::{Read, Write};
 pub struct Connection {
     socket: mio::net::TcpStream,
     token: mio::Token,
-    tls_conn: rustls::ServerConnection,
+    wbuf: Vec<u8>,
     closing: bool,
     closed: bool,
 }
 
 impl Connection {
+    pub fn new(socket: mio::net::TcpStream, token: mio::Token) -> Self {
+        Connection {
+            socket,
+            token,
+            wbuf: Vec::new(),
+            closing: false,
+            closed: false,
+        }
+    }
+    pub fn shutdown(&mut self, how: std::net::Shutdown, registry: &mio::Registry) {
+        match self.socket.shutdown(how) {
+            _ => {
+                self.closed = true;
+                self.deregister(registry);
+            }
+        }
+    }
+    pub fn is_closing(&self) -> bool {
+        self.closing
+    }
+    pub fn is_closed(&self) -> bool {
+        self.closed
+    }
+    pub fn register(&mut self, registry: &mio::Registry) {
+        let interest = mio::Interest::READABLE | mio::Interest::WRITABLE;
+        registry
+            .register(&mut self.socket, self.token, interest)
+            .unwrap();
+    }
+    pub fn reregister(&mut self, registry: &mio::Registry) {
+        let interest = mio::Interest::READABLE | mio::Interest::WRITABLE;
+        registry
+            .reregister(&mut self.socket, self.token, interest)
+            .unwrap();
+    }
+    fn deregister(&mut self, registry: &mio::Registry) {
+        registry.deregister(&mut self.socket).unwrap();
+    }
+    pub fn read(&mut self) -> Result<Vec<u8>, ConnectionError> {
+        let mut bufsiz: usize = 1024;
+        let mut buffer: Vec<u8> = vec![];
+        loop {
+            let mut buf: Vec<u8> = vec![0; bufsiz];
+            match self.socket.read(&mut buf) {
+                Ok(0) => return Ok(buffer),
+                Ok(size) => {
+                    buffer.append(&mut buf);
+                    if size == bufsiz {
+                        bufsiz *= 2;
+                    } else {
+                        return Ok(buffer);
+                    }
+                }
+                Err(e) => return Err(ConnectionError::PlainRead(e)),
+            }
+        }
+    }
+    pub fn write_b(&mut self, buf: Vec<u8>) -> std::io::Result<usize> {
+        self.wbuf.write(&buf)
+    }
+    pub fn write(&mut self) -> Result<usize, ConnectionError> {
+        match self.socket.write(&self.wbuf) {
+            Ok(size) => {
+                trace!("write plaintext to session: {} bytes", size);
+                self.wbuf.clear();
+                Ok(size)
+            }
+            Err(e) => Err(ConnectionError::PlainWrite(e)),
+        }
+    }
+}
+
+pub struct SecureConnection {
+    socket: mio::net::TcpStream,
+    token: mio::Token,
+    tls_conn: rustls::ServerConnection,
+    closing: bool,
+    closed: bool,
+}
+
+impl SecureConnection {
     pub fn new(
         socket: mio::net::TcpStream,
         token: mio::Token,
         tls_conn: rustls::ServerConnection,
     ) -> Self {
-        Connection {
+        SecureConnection {
             socket,
             token,
             tls_conn,

--- a/src/srv/http.rs
+++ b/src/srv/http.rs
@@ -1,40 +1,71 @@
 use crate::{
     cli::{Builder, CliOpt},
-    net::{SimpleTcpSocket, SocketBuilder},
-    srv::{ConnectionHandler, Server, ServerError, ServerRootBuilder},
-    syn::{ThreadPool, ThreadPoolBuilder},
+    net::{SocketBuilder, TcpSocket},
+    srv::{
+        ConnectionHandler, Server, ServerError, ServerRootBuilder, SERVER_QUEUE_SIZE,
+        SERVER_SOCKET_TOKEN,
+    },
+    syn::ThreadPoolBuilder,
     web::{HttpAdapter, HttpReceiver, HttpRequest, HttpResponder, HttpResponse, ToBuffer},
 };
 use log::{debug, error, info};
-use std::{
-    io::{BufRead, BufReader, Write},
-    net::TcpStream,
-    path::PathBuf,
-    sync::Arc,
-};
+use std::{collections::HashMap, path::PathBuf};
+
+use super::conn::Connection;
 
 pub struct HttpServer {
-    socket: SimpleTcpSocket,
-    threads: ThreadPool,
-    root: Arc<PathBuf>,
+    socket: TcpSocket,
+    connections: HashMap<mio::Token, Connection>,
+    poll: mio::Poll,
+    root: PathBuf,
+    nxid: usize,
 }
 
 impl Server<Self, ServerError> for HttpServer {
     fn new(opts: Vec<CliOpt>) -> Self {
         info!("initializing http server: {:?}", &opts);
 
-        let socket_builder = SocketBuilder::<SimpleTcpSocket>::new(opts);
+        let socket_builder = SocketBuilder::<TcpSocket>::new(opts);
         let thread_pool_builder = ThreadPoolBuilder::new(socket_builder.other());
         let server_root_builder = ServerRootBuilder::new(thread_pool_builder.other());
 
-        let socket = socket_builder.build().unwrap();
-        let threads = thread_pool_builder.build().unwrap();
+        let mut socket = socket_builder.build().unwrap();
         let root = server_root_builder.build().unwrap();
+
+        let poll = match mio::Poll::new() {
+            Ok(v) => v,
+            Err(e) => {
+                error!("error creating poll instance: {:?}", e);
+                panic!();
+            }
+        };
+
+        match poll
+            .registry()
+            .register(&mut socket, SERVER_SOCKET_TOKEN, mio::Interest::READABLE)
+        {
+            Ok(_) => debug!(
+                "registered readable interest for server socket: {:?}",
+                &socket
+            ),
+            Err(e) => {
+                error!(
+                    "error registering readable interest for server socket: {:?}: {:?}",
+                    &socket, e
+                );
+                panic!();
+            }
+        }
+
+        let connections = HashMap::new();
+        let nxid = 1;
 
         HttpServer {
             socket,
-            threads,
-            root: Arc::new(root),
+            connections,
+            poll,
+            root,
+            nxid,
         }
     }
     fn request(buf: &mut [u8]) -> Result<HttpRequest, ServerError> {
@@ -49,36 +80,95 @@ impl Server<Self, ServerError> for HttpServer {
 
 impl ConnectionHandler<ServerError> for HttpServer {
     fn listen(&mut self) {
-        info!("listening for connections on socket {:?}", &self.socket);
-        for stream in self.socket.incoming() {
-            let mut stream = stream.unwrap();
-            let root = self.root.clone();
-            self.threads.execute(move || {
-                debug!("received tcp connection");
-                match Self::handle(&mut stream, root) {
-                    Ok(buf) => {
-                        let _ = stream.write(&buf);
-                    }
-                    Err(e) => {
-                        error!("error while handling connection: {:?}", e);
+        info!(
+            "listening for connections on socket {:?}",
+            self.socket.socket().local_addr().unwrap()
+        );
+        let mut events = mio::Events::with_capacity(SERVER_QUEUE_SIZE);
+        loop {
+            match self.poll.poll(&mut events, None) {
+                Ok(_) => {
+                    for event in events.iter() {
+                        match event.token() {
+                            SERVER_SOCKET_TOKEN => match self.accept() {
+                                Err(e) => error!("error accepting connection: {:?}", e),
+                                _ => {}
+                            },
+                            _ => match self.event(event) {
+                                Err(e) => error!("error handling request: {:?}", e),
+                                _ => {}
+                            },
+                        }
                     }
                 }
-            })
+                Err(e) => {
+                    error!("socket polling error: {:?}", e);
+                }
+            }
         }
     }
-    fn handle(stream: &mut TcpStream, root: Arc<PathBuf>) -> Result<Vec<u8>, ServerError> {
-        let mut buf = match BufReader::new(stream).fill_buf() {
-            Ok(v) => {
-                debug!("read data from session: {} bytes", v.len());
-                v.to_vec()
+    fn accept(&mut self) -> Result<(), ServerError> {
+        loop {
+            match self.socket.accept() {
+                Ok((socket, _)) => {
+                    debug!("accepting new connection on socket: from: {:?}", &socket);
+                    let token = mio::Token(self.nxid);
+                    let mut connection = Connection::new(socket, token);
+                    connection.register(self.poll.registry());
+                    self.connections.insert(token, connection);
+
+                    self.nxid += 1;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => return Ok(()),
+                Err(e) => {
+                    error!("error accepting connection: {:?}", e);
+                    return Err(ServerError::SessionIo(e));
+                }
             }
-            Err(e) => {
-                error!("error reading data from session: {:?}", e);
-                return Err(ServerError::SessionIo(e));
+        }
+    }
+    fn event(&mut self, event: &mio::event::Event) -> Result<(), ServerError> {
+        let token = event.token();
+        if self.connections.contains_key(&token) {
+            match Self::handle(
+                event,
+                self.connections.get_mut(&token).unwrap(),
+                &self.poll,
+                &self.root,
+            ) {
+                Err(e) => error!("error handling connection: {:?}", e),
+                _ => {}
             }
-        };
-        let request = Self::request(&mut buf)?;
-        let response = Self::response(&request, &root);
-        Ok(response.to_buf())
+
+            if self.connections.get(&token).unwrap().is_closed() {
+                self.connections.remove(&token);
+            }
+        }
+        Ok(())
+    }
+    fn handle(
+        event: &mio::event::Event,
+        conn: &mut Connection,
+        poll: &mio::Poll,
+        root: &PathBuf,
+    ) -> Result<(), ServerError> {
+        if event.is_readable() {
+            let mut buf = conn.read()?;
+            let request = Self::request(&mut buf)?;
+            let response = Self::response(&request, &root);
+            conn.write_b(response.to_buf())?;
+        }
+
+        if event.is_writable() {
+            conn.write()?;
+        }
+
+        if conn.is_closing() {
+            conn.shutdown(std::net::Shutdown::Both, poll.registry());
+        } else {
+            conn.reregister(poll.registry());
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Leaves connections intact, and polls sockets for readable/writeable interest. Uses a simple write buffer w/ flushing on writeable.